### PR TITLE
Feature/update texts

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-05T13:33:23.289Z\n"
-"PO-Revision-Date: 2018-11-05T13:33:23.289Z\n"
+"POT-Creation-Date: 2019-03-07T06:09:03.347Z\n"
+"PO-Revision-Date: 2019-03-07T06:09:03.347Z\n"
 
 msgid "Setting updated"
 msgstr ""
@@ -17,16 +17,36 @@ msgstr ""
 msgid "Phone"
 msgstr ""
 
-msgid "Enable message email notifications"
+msgid "Enable email forwarding (All)"
 msgstr ""
 
-msgid "Enable message SMS notifications"
+msgid ""
+"You will receive a copy of ALL messages sent to your DHIS inbox. This "
+"includes mentions, new interpretations and comments to subcribed objects, "
+"system notification, validation notifications, etc."
 msgstr ""
 
-msgid "OptOut weekly digest email"
+msgid "Enable SMS forwarding (All)"
 msgstr ""
 
-msgid "OptOut @notification emails"
+msgid ""
+"You will receive a SMS notification for ALL messages sent to your DHIS "
+"inbox. This includes mentions, new interpretations and comments to "
+"subcribed objects, system notification, validation notifications, etc."
+msgstr ""
+
+msgid "Ot-Out of @mention email notifications"
+msgstr ""
+
+msgid "We will not forward direct @mentions to your inbox"
+msgstr ""
+
+msgid "Opt-Out of Weekly digest email"
+msgstr ""
+
+msgid ""
+"By Default, all users receive a weekly digest for all favorites that they "
+"have subscribed to. You can opt-out from receiving  this weekly digest"
 msgstr ""
 
 msgid "PSI Notification Settings app"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-07T06:09:03.347Z\n"
-"PO-Revision-Date: 2019-03-07T06:09:03.347Z\n"
+"POT-Creation-Date: 2019-03-11T15:45:31.817Z\n"
+"PO-Revision-Date: 2019-03-11T15:45:31.817Z\n"
 
 msgid "Setting updated"
 msgstr ""
@@ -35,7 +35,7 @@ msgid ""
 "subcribed objects, system notification, validation notifications, etc."
 msgstr ""
 
-msgid "Ot-Out of @mention email notifications"
+msgid "Opt-Out of @mention email notifications"
 msgstr ""
 
 msgid "We will not forward direct @mentions to your inbox"
@@ -50,6 +50,15 @@ msgid ""
 msgstr ""
 
 msgid "PSI Notification Settings app"
+msgstr ""
+
+msgid "DHIS Message forwarding"
+msgstr ""
+
+msgid "DHIS can forward some or all of the messages that are sent to your "
+msgstr ""
+
+msgid "DHIS messages inbox"
 msgstr ""
 
 msgid "Invalid email"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-03-07T06:09:03.347Z\n"
+"POT-Creation-Date: 2019-03-11T15:45:31.817Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,7 +42,7 @@ msgstr ""
 "suscritos, notificación del sistema, notificaciones de validación, etc."
 
 #, fuzzy
-msgid "Ot-Out of @mention email notifications"
+msgid "Opt-Out of @mention email notifications"
 msgstr "Habilitar notificaciones por correo-e"
 
 msgid "We will not forward direct @mentions to your inbox"
@@ -61,6 +61,15 @@ msgstr ""
 
 msgid "PSI Notification Settings app"
 msgstr "Aplicación de configuración de notificaciones PSI"
+
+msgid "DHIS Message forwarding"
+msgstr "Reenvío de mensajes DHIS"
+
+msgid "DHIS can forward some or all of the messages that are sent to your "
+msgstr "DHIS puede reenviar algunos o todos los mensajes que se envían a su "
+
+msgid "DHIS messages inbox"
+msgstr "bandeja de entrada DHIS"
 
 msgid "Invalid email"
 msgstr "E-mail inválido"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2018-11-05T13:33:23.289Z\n"
+"POT-Creation-Date: 2019-03-07T06:09:03.347Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,17 +17,47 @@ msgstr "E-mail"
 msgid "Phone"
 msgstr "Número de teléfono móvil"
 
-msgid "Enable message email notifications"
+msgid "Enable email forwarding (All)"
+msgstr "Habilitar el reenvío de correo electrónico (Todos)"
+
+msgid ""
+"You will receive a copy of ALL messages sent to your DHIS inbox. This "
+"includes mentions, new interpretations and comments to subcribed objects, "
+"system notification, validation notifications, etc."
+msgstr ""
+"Recibirá una copia de TODOS los mensajes enviados a su bandeja de entrada de DHIS. Esto "
+"incluye menciones, nuevas interpretaciones y comentarios a los objetos suscritos,"
+"notificación del sistema, notificaciones de validación, etc."
+
+msgid "Enable SMS forwarding (All)"
+msgstr "Habilitar reenvío de SMS (Todos)"
+
+msgid ""
+"You will receive a SMS notification for ALL messages sent to your DHIS "
+"inbox. This includes mentions, new interpretations and comments to subcribed "
+"objects, system notification, validation notifications, etc."
+msgstr ""
+"Recibirá una notificación por SMS para TODOS los mensajes enviados a su "
+"bandeja de entrada de DHIS. Esto incluye menciones, nuevas interpretaciones y comentarios a los objetos ".
+"suscritos, notificación del sistema, notificaciones de validación, etc."
+
+#, fuzzy
+msgid "Ot-Out of @mention email notifications"
 msgstr "Habilitar notificaciones por correo-e"
 
-msgid "Enable message SMS notifications"
-msgstr "Habilitar notificaciones para SMS"
+msgid "We will not forward direct @mentions to your inbox"
+msgstr "No reenviaremos @mentions directos a su bandeja de entrada."
 
-msgid "OptOut weekly digest email"
+#, fuzzy
+msgid "Opt-Out of Weekly digest email"
 msgstr "Desactictivar correo de resumen semanal"
 
-msgid "OptOut @notification emails"
-msgstr "Desactivar @menciones"
+msgid ""
+"By Default, all users receive a weekly digest for all favorites that they "
+"have subscribed to. You can opt-out from receiving this weekly digest"
+msgstr ""
+"Por defecto, todos los usuarios reciben un resumen semanal de todos los favoritos a los que ellos "
+"se han suscrito. Puede optar por no recibir este resumen semanal"
 
 msgid "PSI Notification Settings app"
 msgstr "Aplicación de configuración de notificaciones PSI"
@@ -37,3 +67,9 @@ msgstr "E-mail inválido"
 
 msgid "Invalid phone number"
 msgstr "Número inválido"
+
+#~ msgid "Enable message SMS notifications"
+#~ msgstr "Habilitar notificaciones para SMS"
+
+#~ msgid "OptOut @notification emails"
+#~ msgstr "Desactivar @menciones"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,12 +1,12 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
+"POT-Creation-Date: 2019-03-07T06:09:03.347Z\n"
+"PO-Revision-Date: 2018-11-05T13:33:23.289Z\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-05T13:33:23.289Z\n"
-"PO-Revision-Date: 2018-11-05T13:33:23.289Z\n"
 
 msgid "Setting updated"
 msgstr ""
@@ -17,16 +17,36 @@ msgstr ""
 msgid "Phone"
 msgstr ""
 
-msgid "Enable message email notifications"
+msgid "Enable email forwarding (All)"
 msgstr ""
 
-msgid "Enable message SMS notifications"
+msgid ""
+"You will receive a copy of ALL messages sent to your DHIS inbox. This "
+"includes mentions, new interpretations and comments to subcribed objects, "
+"system notification, validation notifications, etc."
 msgstr ""
 
-msgid "OptOut weekly digest email"
+msgid "Enable SMS forwarding (All)"
 msgstr ""
 
-msgid "OptOut @notification emails"
+msgid ""
+"You will receive a SMS notification for ALL messages sent to your DHIS "
+"inbox. This includes mentions, new interpretations and comments to subcribed "
+"objects, system notification, validation notifications, etc."
+msgstr ""
+
+msgid "Ot-Out of @mention email notifications"
+msgstr ""
+
+msgid "We will not forward direct @mentions to your inbox"
+msgstr ""
+
+msgid "Opt-Out of Weekly digest email"
+msgstr ""
+
+msgid ""
+"By Default, all users receive a weekly digest for all favorites that they "
+"have subscribed to. You can opt-out from receiving  this weekly digest"
 msgstr ""
 
 msgid "PSI Notification Settings app"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-03-07T06:09:03.347Z\n"
+"POT-Creation-Date: 2019-03-11T15:45:31.817Z\n"
 "PO-Revision-Date: 2018-11-05T13:33:23.289Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -35,7 +35,7 @@ msgid ""
 "objects, system notification, validation notifications, etc."
 msgstr ""
 
-msgid "Ot-Out of @mention email notifications"
+msgid "Opt-Out of @mention email notifications"
 msgstr ""
 
 msgid "We will not forward direct @mentions to your inbox"
@@ -50,6 +50,15 @@ msgid ""
 msgstr ""
 
 msgid "PSI Notification Settings app"
+msgstr ""
+
+msgid "DHIS Message forwarding"
+msgstr ""
+
+msgid "DHIS can forward some or all of the messages that are sent to your "
+msgstr ""
+
+msgid "DHIS messages inbox"
 msgstr ""
 
 msgid "Invalid email"

--- a/src/components/NotificationsForm.js
+++ b/src/components/NotificationsForm.js
@@ -29,7 +29,8 @@ class NotificationsForm extends React.Component {
     styles = {
         cardContent: { width: 800 },
         textField: { width: '100%' },
-        subtitle2: { fontWeight: 'bold' }
+        subtitle2: { fontWeight: 'bold' },
+        marginTop: { marginTop: '20px'}
     }
 
     state = {
@@ -201,7 +202,7 @@ class NotificationsForm extends React.Component {
                             fields={this.getFirstSectionFields()}
                             onUpdateField={this.onUpdateField}
                         />
-                        <Typography gutterBottom variant="h6" component="h3">
+                        <Typography gutterBottom variant="h6" component="h3" style={this.styles.marginTop}>
                             {i18n.t('DHIS Message forwarding')}
                         </Typography>
                         <Typography gutterBottom variant="subtitle1">

--- a/src/components/NotificationsForm.js
+++ b/src/components/NotificationsForm.js
@@ -64,8 +64,6 @@ class NotificationsForm extends React.Component {
     }
 
     getFirstSectionFields() {
-        const { settings } = this.state
-
         return _([
             this.getTextField({
                 name: 'email',
@@ -124,7 +122,8 @@ class NotificationsForm extends React.Component {
                         <Typography gutterBottom variant="body2">
                             {i18n.t('We will not forward direct @mentions to your inbox')}
                         </Typography>
-                    </div>
+                    </div>,
+                disabled: settings.get('emailNotifications'),
             }),
 
             this.getBooleanField({

--- a/src/components/NotificationsForm.js
+++ b/src/components/NotificationsForm.js
@@ -63,7 +63,7 @@ class NotificationsForm extends React.Component {
         }
     }
 
-    getFields() {
+    getFirstSectionFields() {
         const { settings } = this.state
 
         return _([
@@ -78,31 +78,72 @@ class NotificationsForm extends React.Component {
                 label: i18n.t('Phone'),
                 validators: validators.phone,
             }),
-
-            this.getBooleanField({
-                name: 'emailNotifications',
-                label: i18n.t('Enable message email notifications'),
-            }),
-
-            this.getBooleanField({
-                name: 'smsNotifications',
-                label: i18n.t('Enable message SMS notifications'),
-            }),
-
-            this.getBooleanField({
-                name: 'noNewsletters',
-                label: i18n.t('OptOut weekly digest email'),
-            }),
-
-            this.getBooleanField({
-                name: 'noMentionNotifications',
-                label: i18n.t('OptOut @notification emails'),
-                disabled: settings.get('emailNotifications'),
-            }),
         ])
             .compact()
             .value()
     }
+
+    getLastSectionFields() {
+        const { settings } = this.state
+
+        return _([
+
+            this.getBooleanField({
+                name: 'emailNotifications',
+                label:
+                    <div>
+                        <Typography gutterBottom variant="subtitle2">
+                            {i18n.t('Enable email forwarding (All)')}
+                        </Typography>
+                        <Typography gutterBottom variant="body2">
+                            {i18n.t('You will receive a copy of ALL messages sent to your DHIS inbox. This includes mentions, new interpretations and comments to subcribed objects, system notification, validation notifications, etc.')}
+                        </Typography>
+                    </div>
+            }),
+
+            this.getBooleanField({
+                name: 'smsNotifications',
+                label:
+                    <div>
+                        <Typography gutterBottom variant="subtitle2">
+                            {i18n.t('Enable SMS forwarding (All)')}
+                        </Typography>
+                        <Typography gutterBottom variant="body2">
+                            {i18n.t('You will receive a SMS notification for ALL messages sent to your DHIS inbox. This includes mentions, new interpretations and comments to subcribed objects, system notification, validation notifications, etc.')}
+                        </Typography>
+                    </div>
+            }),
+
+            this.getBooleanField({
+                name: 'noMentionNotifications',
+                label:
+                    <div>
+                        <Typography gutterBottom variant="subtitle2">
+                            {i18n.t('Ot-Out of @mention email notifications')}
+                        </Typography>
+                        <Typography gutterBottom variant="body2">
+                            {i18n.t('We will not forward direct @mentions to your inbox')}
+                        </Typography>
+                    </div>
+            }),
+
+            this.getBooleanField({
+                name: 'noNewsletters',
+                label:
+                    <div>
+                        <Typography gutterBottom variant="subtitle2">
+                            {i18n.t('Opt-Out of Weekly digest email')}
+                        </Typography>
+                        <Typography gutterBottom variant="body2">
+                            {i18n.t('By Default, all users receive a weekly digest for all favorites that they have subscribed to. You can opt-out from receiving  this weekly digest')}
+                        </Typography>
+                    </div>
+            })
+        ])
+            .compact()
+            .value()
+    }
+
 
     getBooleanField({ name, label, disabled = false }) {
         const { settings } = this.state
@@ -157,7 +198,18 @@ class NotificationsForm extends React.Component {
                         </Typography>
 
                         <FormBuilder
-                            fields={this.getFields()}
+                            fields={this.getFirstSectionFields()}
+                            onUpdateField={this.onUpdateField}
+                        />
+                        <Typography gutterBottom variant="h6" component="h3">
+                            {'DHIS Message forwarding'}
+                        </Typography>
+                        <Typography gutterBottom variant="subtitle1">
+                            {'DHIS can forward some or all of the messages that are sent to your '}
+                            <a href="/dhis-web-messaging">{'DHIS messages inbox'}</a>
+                        </Typography>
+                        <FormBuilder
+                            fields={this.getLastSectionFields()}
                             onUpdateField={this.onUpdateField}
                         />
                     </div>

--- a/src/components/NotificationsForm.js
+++ b/src/components/NotificationsForm.js
@@ -27,10 +27,11 @@ class NotificationsForm extends React.Component {
     }
 
     styles = {
-        cardContent: { width: 800 },
+        cardContent: { width: 800, marginLeft: 10, marginTop: 5 },
         textField: { width: '100%' },
+        title: { fontWeight: 'bold', marginBottom: 0 },
         subtitle2: { fontWeight: 'bold' },
-        marginTop: { marginTop: '20px'}
+        subtitle1: { fontWeight: 'bold', marginTop: '30px'}
     }
 
     state = {
@@ -194,7 +195,7 @@ class NotificationsForm extends React.Component {
             case 'loaded':
                 return (
                     <div className="notifications-form">
-                        <Typography gutterBottom variant="h5" component="h2">
+                        <Typography gutterBottom variant="h5" component="h2" style={this.styles.title}>
                             {i18n.t('PSI Notification Settings app')}
                         </Typography>
 
@@ -202,7 +203,7 @@ class NotificationsForm extends React.Component {
                             fields={this.getFirstSectionFields()}
                             onUpdateField={this.onUpdateField}
                         />
-                        <Typography gutterBottom variant="h6" component="h3" style={this.styles.marginTop}>
+                        <Typography gutterBottom variant="h6" component="h3" style={this.styles.subtitle1}>
                             {i18n.t('DHIS Message forwarding')}
                         </Typography>
                         <Typography gutterBottom variant="subtitle1">

--- a/src/components/NotificationsForm.js
+++ b/src/components/NotificationsForm.js
@@ -29,6 +29,7 @@ class NotificationsForm extends React.Component {
     styles = {
         cardContent: { width: 800 },
         textField: { width: '100%' },
+        subtitle2: { fontWeight: 'bold' }
     }
 
     state = {
@@ -90,7 +91,7 @@ class NotificationsForm extends React.Component {
                 name: 'emailNotifications',
                 label:
                     <div>
-                        <Typography gutterBottom variant="subtitle2">
+                        <Typography gutterBottom variant="subtitle2" style={this.styles.subtitle2}>
                             {i18n.t('Enable email forwarding (All)')}
                         </Typography>
                         <Typography gutterBottom variant="body2">
@@ -103,7 +104,7 @@ class NotificationsForm extends React.Component {
                 name: 'smsNotifications',
                 label:
                     <div>
-                        <Typography gutterBottom variant="subtitle2">
+                        <Typography gutterBottom variant="subtitle2" style={this.styles.subtitle2}>
                             {i18n.t('Enable SMS forwarding (All)')}
                         </Typography>
                         <Typography gutterBottom variant="body2">
@@ -116,8 +117,8 @@ class NotificationsForm extends React.Component {
                 name: 'noMentionNotifications',
                 label:
                     <div>
-                        <Typography gutterBottom variant="subtitle2">
-                            {i18n.t('Ot-Out of @mention email notifications')}
+                        <Typography gutterBottom variant="subtitle2" style={this.styles.subtitle2}>
+                            {i18n.t('Opt-Out of @mention email notifications')}
                         </Typography>
                         <Typography gutterBottom variant="body2">
                             {i18n.t('We will not forward direct @mentions to your inbox')}
@@ -130,7 +131,7 @@ class NotificationsForm extends React.Component {
                 name: 'noNewsletters',
                 label:
                     <div>
-                        <Typography gutterBottom variant="subtitle2">
+                        <Typography gutterBottom variant="subtitle2" style={this.styles.subtitle2}>
                             {i18n.t('Opt-Out of Weekly digest email')}
                         </Typography>
                         <Typography gutterBottom variant="body2">
@@ -201,11 +202,11 @@ class NotificationsForm extends React.Component {
                             onUpdateField={this.onUpdateField}
                         />
                         <Typography gutterBottom variant="h6" component="h3">
-                            {'DHIS Message forwarding'}
+                            {i18n.t('DHIS Message forwarding')}
                         </Typography>
                         <Typography gutterBottom variant="subtitle1">
-                            {'DHIS can forward some or all of the messages that are sent to your '}
-                            <a href="/dhis-web-messaging">{'DHIS messages inbox'}</a>
+                            {i18n.t('DHIS can forward some or all of the messages that are sent to your ')}
+                            <a href="/dhis-web-messaging">{i18n.t('DHIS messages inbox')}</a>
                         </Typography>
                         <FormBuilder
                             fields={this.getLastSectionFields()}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Close #6   

### :memo: Implementation

I have added new sections and subtitle for last fields using typography component applying styles according to the [material-ui  documentation](https://material-ui.com/style/typography/)

### :art: Screenshots
![psi notification settings app](https://user-images.githubusercontent.com/5593590/53937369-32f5cc00-40ad-11e9-9704-8b82665484c7.png)

### :fire: Is there anything the reviewer should know to test it?

### :bookmark_tabs: Others

When running yarn update-po it failed because it did not have gettext installed.
From Mac I used these commands:
```shell
brew install gettext
brew link --force gettext
```
Maybe we should add it in the readme.